### PR TITLE
Setup fastlane

### DIFF
--- a/feelin/ios/.gitignore
+++ b/feelin/ios/.gitignore
@@ -32,3 +32,5 @@ Runner/GeneratedPluginRegistrant.*
 !default.mode2v3
 !default.pbxuser
 !default.perspectivev3
+
+fastlane/report.xml

--- a/feelin/ios/Gemfile
+++ b/feelin/ios/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "fastlane"

--- a/feelin/ios/fastlane/Appfile
+++ b/feelin/ios/fastlane/Appfile
@@ -1,0 +1,2 @@
+apple_id "apple@wafflestudio.com"
+team_id "K9883YB4VR"

--- a/feelin/ios/fastlane/Fastfile
+++ b/feelin/ios/fastlane/Fastfile
@@ -1,0 +1,43 @@
+# This file contains the fastlane.tools configuration
+# You can find the documentation at https://docs.fastlane.tools
+#
+# For a list of all available actions, check out
+#
+#     https://docs.fastlane.tools/actions
+#
+# For a list of all available plugins, check out
+#
+#     https://docs.fastlane.tools/plugins/available-plugins
+#
+
+# Uncomment the line if you want fastlane to automatically update itself
+# update_fastlane
+
+BUNDLE_IDENTIFIER = "com.wafflestudio.feelin"
+XCODEPROJ_NAME = "Runner.xcodeproj"
+TEAM_ID = "K9883YB4VR"
+SCHEME_NAME = "Runner"
+
+default_platform(:ios)
+
+platform :ios do
+  desc "🛠️ Update xcodeproj file"
+  private_lane :update_xcodeproj do |options|
+    code_sign_identity = options[:type] == 'appstore' ? 'iPhone Distribution' : 'iPhone Developer'
+    update_code_signing_settings(
+      use_automatic_signing: false,
+      path: XCODEPROJ_NAME,
+      team_id: TEAM_ID,
+      targets: SCHEME_NAME,
+      bundle_identifier: BUNDLE_IDENTIFIER,
+      code_sign_identity:  code_sign_identity,
+      profile_name: ENV["sigh_#{BUNDLE_IDENTIFIER}_#{options[:type]}_profile-name"],
+      )
+  end
+
+  desc "🔐 Configure certificates and provisioning profiles for distribution"
+  lane :certificates_distribution do
+    match(type: "appstore", app_identifier: [BUNDLE_IDENTIFIER], readonly: true)
+    update_xcodeproj(type: "appstore")
+  end
+end

--- a/feelin/ios/fastlane/Matchfile
+++ b/feelin/ios/fastlane/Matchfile
@@ -1,0 +1,3 @@
+git_url("https://github.com/wafflestudio/wafflestudio-apple-certificates")
+storage_mode("git")
+username("apple@wafflestudio.com")

--- a/feelin/ios/fastlane/README.md
+++ b/feelin/ios/fastlane/README.md
@@ -1,0 +1,32 @@
+fastlane documentation
+----
+
+# Installation
+
+Make sure you have the latest version of the Xcode command line tools installed:
+
+```sh
+xcode-select --install
+```
+
+For _fastlane_ installation instructions, see [Installing _fastlane_](https://docs.fastlane.tools/#installing-fastlane)
+
+# Available Actions
+
+## iOS
+
+### ios certificates_distribution
+
+```sh
+[bundle exec] fastlane ios certificates_distribution
+```
+
+🔐 Configure certificates and provisioning profiles for distribution
+
+----
+
+This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.
+
+More information about _fastlane_ can be found on [fastlane.tools](https://fastlane.tools).
+
+The documentation of _fastlane_ can be found on [docs.fastlane.tools](https://docs.fastlane.tools).


### PR DESCRIPTION
`com.wafflestudio.feelin` 번들 ID 으로 빌드할 수 있도록 certificate과 provisioning profile을 자동으로 설치해주는 스크립트입니다.

# Steps

1. `brew install fastlane`
2. `cd ios`
3. `fastlane certificates_distribution`
4. passphrase 입력 (DM으로 전달 예정) 
5. xcodeproj 파일이 잘 업데이트되었는지 확인, 빌드 되는지 확인
6. 빌드가 성공한다면, Archive 후 Distribute App 해주시면 됩니다. 현석님께 App Store Connect 권한을 부여해드렸으니, 그 계정으로 distribute 해주시면 될거에요.

제가 했을 땐 빌드가 실패하던데, 로그를 보니 certificate 관련 문제는 아닌 것 같습니다. 한번 확인 부탁드려요.


